### PR TITLE
Crystal Empire event now working

### DIFF
--- a/events/pony.txt
+++ b/events/pony.txt
@@ -213,14 +213,17 @@ country_event = {
 	trigger = {
 		NOT = { exists = EQL }
 		NOT = { has_country_flag = crystal_revolution }
+		
 		is_year = 1650
+		
 		OR = {
-		tag = EQC
-		tag = EQE
-		tag = EQN
-		tag = EQP
-		tag = EQU
+			tag = EQC
+			tag = EQE
+			tag = EQN
+			tag = EQP
+			tag = EQU
 		}
+		
 		northern_america = {
 			is_core = ROOT
 		}
@@ -228,7 +231,6 @@ country_event = {
 	
 	mean_time_to_happen = {
 		months = 120
-
 	}
 	
 	option = {


### PR DESCRIPTION
The Crystal Empire should now fire and will now get a core on the northern region, region. The button now works. It was broken because of the triggers, you used region_name instead of region, for the limit, which is not a command and caused the event to break.
